### PR TITLE
Switch to SSL endpoints

### DIFF
--- a/gcs.js
+++ b/gcs.js
@@ -14,7 +14,7 @@ GCS.prototype.putStream = function(stream, bucket, filepath, headers, callback) 
         headers.Host = 'storage.googleapis.com';
         headers['x-goog-api-version'] = 2;
 
-        var url = 'http://storage.googleapis.com/' + bucket + filepath;
+        var url = 'https://storage.googleapis.com/' + bucket + filepath;
 
         stream.resume();
         stream.pipe(request.put(url, {headers: headers}, callback));
@@ -32,7 +32,7 @@ GCS.prototype.deleteFile = function(bucket, filepath, callback) {
         headers['Content-Length'] = 0;
         headers['x-goog-api-version'] = 2;
 
-        var url = 'http://storage.googleapis.com/' + bucket + filepath;
+        var url = 'https://storage.googleapis.com/' + bucket + filepath;
 
         request.del(url, {headers: headers}, callback);
     });


### PR DESCRIPTION
This has been supported[1] by Google Cloud Storage for some time, and resolves issues with insecure content warnings when using this library to supply resources to HTTPS webpages.

Cheers & thanks for the handy library!

[1] https://cloud.google.com/storage/docs/reference-uris
