### PR TITLE
Bump the gapitoken dependency to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-gcs",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Node.js wrapper for Google Cloud Storage API v2.0",
 	"main": "gcs.js",
 	"repository": {
@@ -19,6 +19,6 @@
 	"readmeFilename": "README.md",
 	"dependencies": {
 		"request": "2.14.0",
-		"gapitoken": "0.1.0"
+		"gapitoken": "0.1.5"
 	}
 }


### PR DESCRIPTION
Also bump the patch version to 0.0.5 to make this change available.

This is because the old gapitoken version uses a deprecated version of jws as a dependency.
